### PR TITLE
fix(err): Flask object is part of connexion.FlaskApp.app

### DIFF
--- a/src/flask_endpoint.py
+++ b/src/flask_endpoint.py
@@ -43,8 +43,8 @@ app = connexion.FlaskApp(__name__)
 setup_logging(app.app)
 CORS(app.app)
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
-sentry = Sentry(app, dsn=SENTRY_DSN, logging=True, level=logging.ERROR)
-app.logger.info('App initialized, ready to roll...')
+sentry = Sentry(app.app, dsn=SENTRY_DSN, logging=True, level=logging.ERROR)
+app.app.logger.info('App initialized, ready to roll...')
 
 global scoring_status
 global scoring_object


### PR DESCRIPTION
# Description

We must pass `Flask` object to instantiate Sentry class, however the existing code passes `connexion.FlaskApp` which is incorrect. `Flask` which is created by connexion shall be accessed using `connexion.FlaskApp.app`.

Fixes https://issues.redhat.com/browse/APPAI-1265.