### PR TITLE
fix: Ignoring case sensitivity in deployment prefix value, default recall to 55%

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -467,7 +467,7 @@ def create_git_pr(s3_client, hyper_params, deployment_type):  # pragma: no cover
                                                                       deployment_type)
 
     recall_at_30 = hyper_params['recall_at_30']
-    deployed_recall_at_30 = deployed_data['hyperparams'].get('recall_at_30', 0.30)
+    deployed_recall_at_30 = deployed_data['hyperparams'].get('recall_at_30', 0.55)
     logger.info('create_git_pr:: Deployed => Model %s, Recall %f Current => Model %s, Recall %f',
                 deployed_data['version'], deployed_recall_at_30, MODEL_VERSION, recall_at_30)
     if recall_at_30 >= deployed_recall_at_30:
@@ -508,7 +508,7 @@ def train_model():
         'PROD': 'production'
     }
 
-    deployment_type = deployment_prefix_to_type_map.get(DEPLOYMENT_PREFIX, None)
+    deployment_type = deployment_prefix_to_type_map.get(DEPLOYMENT_PREFIX.upper(), None)
     assert deployment_type is not None, f'Invalid DEPLOYMENT_PREFIX: {DEPLOYMENT_PREFIX}'
 
     s3_obj = load_s3()


### PR DESCRIPTION


# Description

Handling case sensitivity in defining deployment prefix. Modified default recall value to 55% (as it was production code).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
