### PR TITLE
fix: Set default hyper params to empty object instead of none

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -420,6 +420,7 @@ def read_deployed_data(upstream_repo, s3_client, deployment_type):
     deployed_version = get_deployed_model_version(yaml_dict, deployment_type)
     deployed_file_path = f'{deployed_version}/intermediate-model/hyperparameters.json'
     deployed_hyperparams = s3_client.read_json_file(deployed_file_path)
+    if deployed_hyperparams is None: deployed_hyperparams = {}
 
     deployed_data = {
         'version': deployed_version,

--- a/training/train.py
+++ b/training/train.py
@@ -420,7 +420,8 @@ def read_deployed_data(upstream_repo, s3_client, deployment_type):
     deployed_version = get_deployed_model_version(yaml_dict, deployment_type)
     deployed_file_path = f'{deployed_version}/intermediate-model/hyperparameters.json'
     deployed_hyperparams = s3_client.read_json_file(deployed_file_path)
-    if deployed_hyperparams is None: deployed_hyperparams = {}
+    if deployed_hyperparams is None:
+        deployed_hyperparams = {}
 
     deployed_data = {
         'version': deployed_version,


### PR DESCRIPTION
# Description

There was error while reading old hyper paramters for a ML model as structure and file type are different. Need to handle this in code by setting it to empty dict object instead of none.

Fixes # (issue)
https://issues.redhat.com/browse/APPAI-1920

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
